### PR TITLE
Allow Functions for feed item options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "4.2.0"
+sudo: false
+before_install:
+  - npm config set progress false
+  - npm config set spin false
+  - npm install -g npm@^2
+install:
+  - npm install
+script: npm test

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ metalsmith-feed-js
 
 To each there own and thank you for `hurrymaplelad` for the original metalsmith-feed.
 
-Why the fork? CoffeeScript Sucks (tm)
-
 This is essentially a fork of https://github.com/hurrymaplelad/metalsmith-feed with a few minor improvements to support tags as well as collections.
 
 ---
@@ -71,9 +69,49 @@ metalsmith('example')
 
 - `destination` **string** *Optional*. File path to write the rendered XML feed. Defaults to `'rss.xml'`.
 
+- `itemDataHandlers` **object** *Optional*. Object of functions for custom handling of item values. See [below](#custom-handling-of-item-values)
+
 Remaining options are passed to the [rss](https://github.com/dylang/node-rss) module as `feedOptions`, along with `metadata.site`.
 
 If files have `path` metadata (perhaps from [permalinks](https://github.com/RobinThrift/metalsmith-paginate)) but not `url` metadata, we'll prefix `path` with `site_url` to generate links. Feed item descriptions default to `file.less` from metalsmith-more, `file.excerpt` from metalsmith-excerpt, and finally the full `file.contents`.
+
+### Custom Handling of Item values
+
+In some cases, you'll want finer handling of each key of an item, for instance, the author. By default `metalsmith-feed` will use `site.author` for the `dc:creator` on each feed item. Each post file may also contain an `author` key in its front matter. If you would like to dictate how the value for each key is discovered, you can override default behavior using the `itemDataHandlers`.
+
+In this case, we want a nested structure for author data:
+
+```markdown
+---
+title: My Second Post
+author:
+  name: Janie Jones
+  bio: She's in live with rock'n'roll, woah!
+---
+```
+
+we would write a custom `author` handler function to set the `dc:creator` value on the feed item.
+
+```javascript
+.use(feed({
+  collection: 'posts',
+  itemDataHandlers: {
+    author: (file, defaultValue) => {
+      const author = file.author;
+
+      if (!author) {
+        return defaultValue;
+      }
+
+      if (typeof author === 'string') {
+        return author;
+      } else {
+        return author.name;
+      }
+    }
+  }
+}))
+````
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ metalsmith('example')
 Remaining options are passed to the [rss](https://github.com/dylang/node-rss) module as `feedOptions`, along with `metadata.site`.
 
 If files have `path` metadata (perhaps from [permalinks](https://github.com/RobinThrift/metalsmith-paginate)) but not `url` metadata, we'll prefix `path` with `site_url` to generate links. Feed item descriptions default to `file.less` from metalsmith-more, `file.excerpt` from metalsmith-excerpt, and finally the full `file.contents`.
+
+## Contributing
+
+Pull requests are always welcome.
+
+### Running tests
+
+```
+npm test
+```

--- a/metalsmith-feed.js
+++ b/metalsmith-feed.js
@@ -1,76 +1,103 @@
-var RSS = require('rss')
-var extend = require('extend')
-var url = require('url')
+'use strict';
 
-module.exports = function(options) {
-  var collectionName, destination, limit
-  
-  options = options || {}
-  
-  limit = options.limit || 20
-  destination = options.destination || 'rss.xml'
-  collectionName = options.collection
-  tagName = options.tag
-  tagHandle = options.handle || 'tags'
-  metadataKey = options.metadataKey || 'feeds'
+const RSS = require('rss');
+const extend = require('extend');
+const url = require('url');
+
+const feed = (opts) => {
+  const options = opts || {};
+
+  const limit = options.limit || 20;
+  const destination = options.destination || 'rss.xml';
+  const collectionName = options.collection;
+  const tagName = options.tag;
+  const tagHandle = options.handle || 'tags';
+  const metadataKey = options.metadataKey || 'feeds';
+  const itemDataHandlers = options.itemDataHandlers || null;
 
   if (!collectionName && !tagName) {
     throw new Error('collection or tag option is required');
   }
 
-  return function(files, metalsmith, done) {
-    var collection, tag, feed, feedOptions, file, itemData, metadata, siteUrl, _i, _len, _ref
+  return (files, metalsmith, done) => {
+    var tag, _ref;
 
-    metadata = metalsmith.metadata()
-    metadata[metadataKey] = metadata[metadataKey] || []
+    let collection = null;
+    let metadata = metalsmith.metadata();
+    metadata[metadataKey] = metadata[metadataKey] || [];
+
     if (!metadata.collections && !metadata.tags) {
-      return done(new Error('no collections or tags configured - see metalsmith-collections or metalsmith-tags'))
+      return done(
+        new Error('no collections or tags configured - see metalsmith-collections or metalsmith-tags')
+      );
     }
 
     if (collectionName) {
-      collection = metadata.collections[collectionName]
+      collection = metadata.collections[collectionName];
     }
 
     if (tagName) {
-      collection = metadata[tagHandle][tagName]
+      collection = metadata[tagHandle][tagName];
     }
 
-    feedOptions = extend({}, metadata.site, options, {
+    const feedOptions = extend({}, metadata.site, options, {
       site_url: (_ref = metadata.site) != null ? _ref.url : void 0,
       generator: 'metalsmith-feed'
     });
 
-    siteUrl = feedOptions.site_url
+    const siteUrl = feedOptions.site_url;
+
     if (!siteUrl) {
-      return done(new Error('either site_url or metadata.site.url must be configured'));
+      return done(
+        new Error('either site_url or metadata.site.url must be configured')
+      );
     }
 
     if (feedOptions.feed_url == null) {
       feedOptions.feed_url = url.resolve(siteUrl, destination)
     }
 
-    feed = new RSS(feedOptions)
+    let feed = new RSS(feedOptions);
+
     if (limit) {
-      collection = collection.slice(0, limit)
+      collection = collection.slice(0, limit);
     }
 
-    for (_i = 0, _len = collection.length; _i < _len; _i++) {
-      file = collection[_i]
-      itemData = extend({}, file, {
+    for (let i = 0; i < collection.length; i += 1) {
+      const file = collection[i];
+
+      let itemData = extend({}, file, {
         description: file.less || file.excerpt || file.contents
-      })
+      });
+
       if (!itemData.url && itemData.path) {
         itemData.url = url.resolve(siteUrl, file.path)
       }
+
+      // This is where we allow for custom handling of certain item data.
+      if (itemDataHandlers !== null) {
+        Object.keys(itemDataHandlers).forEach((key) => {
+          const defaultValue = feed[key] || null;
+          const handler = itemDataHandlers[key];
+
+          if (typeof handler === 'function') {
+            itemData[key] = handler(file, defaultValue);
+          }
+        });
+      }
+
       feed.item(itemData)
     }
 
+    // Finally, we create the rss.xml (or provided name) file.
     files[destination] = {
       contents: new Buffer(feed.xml(), 'utf8')
-    }
+    };
+    
+    metadata[metadataKey].push(destination);
 
-    metadata[metadataKey].push(destination)
-
-    return done()
+    return done();
   }
 }
+
+module.exports = feed;

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "tape": "1.1.2",
     "xml2js": "0.4.16",
     "metalsmith": "2.1.0",
-    "metalsmith-collections": "*",
-    "metalsmith-tags": "*"
+    "metalsmith-collections": "0.7.0",
+    "metalsmith-tags": "1.2.1"
   },
   "scripts": {
-    "test": "node tape"
+    "test": "node test/*js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,24 +12,24 @@
   "main": "metalsmith-feed.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ekristen/metalsmith-feed-js.git"
+    "url": "git://github.com/tylergaw/metalsmith-feed-js.git"
   },
-  "homepage": "https://github.com/ekristen/metalsmith-feed-js",
+  "homepage": "https://github.com/tylergaw/metalsmith-feed-js",
   "bugs": {
-    "url": "https://github.com/ekristen/metalsmith-feed-js/issues"
+    "url": "https://github.com/tylergaw/metalsmith-feed-js/issues"
   },
   "license": "MIT",
   "dependencies": {
-    "extend": "~2.0.0",
-    "metalsmith-collections": "~0.6.0",
-    "metalsmith-tags": "^0.8.2",
-    "rss": "~1.0.0"
+    "extend": "2.0.0",
+    "metalsmith-collections": "0.7.0",
+    "metalsmith-tags": "1.2.1",
+    "rss": "1.0.0"
   },
   "devDependencies": {
-    "tape": "*",
-    "xml2js": "*",
-    "metalsmith": "~1.0.1",
-    "metalsmith-collections": "~0.6.0",
+    "tape": "1.1.2",
+    "xml2js": "0.4.16",
+    "metalsmith": "2.1.0",
+    "metalsmith-collections": "*",
     "metalsmith-tags": "*"
   },
   "scripts": {

--- a/test/fixtures/src/a-post.html
+++ b/test/fixtures/src/a-post.html
@@ -1,4 +1,5 @@
 ---
 title: Theory of Juice
+author: Joe Mosely
 ---
 <p>juice appeal</p>

--- a/test/fixtures/src/b-post.html
+++ b/test/fixtures/src/b-post.html
@@ -1,0 +1,7 @@
+---
+title: My Second Post
+author:
+  name: Janie Jones
+  bio: She's in live with rock'n'roll, woah!
+---
+<p>She don't like her boring job, no!</p>

--- a/test/fixtures/src/c-post.html
+++ b/test/fixtures/src/c-post.html
@@ -1,0 +1,4 @@
+---
+title: All The Defaults
+---
+<p>Test for defaults</p>

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,13 @@
-var test = require('tape');
-var metalsmith = require('metalsmith')
-var collections = require('metalsmith-collections')
-var tags = require('metalsmith-tags')
-var feed = require('../metalsmith-feed')
+'use strict';
 
-var parseString = require('xml2js').parseString
+const test = require('tape');
+const metalsmith = require('metalsmith');
+const collections = require('metalsmith-collections');
+const tags = require('metalsmith-tags');
+const feed = require('../metalsmith-feed');
+const parseString = require('xml2js').parseString
 
-var metadata = {
+const metadata = {
   site: {
     title: 'Example',
     url: 'http://www.example.org',
@@ -14,7 +15,7 @@ var metadata = {
   }
 }
 
-test('it renders rss feed', function (t) {
+test('it renders rss feed', (t) => {
   metalsmith('test/fixtures')
     .metadata(metadata)
     .use(collections({
@@ -23,43 +24,43 @@ test('it renders rss feed', function (t) {
     .use(feed({
       collection: 'posts'
     }))
-    .build(function(err, files) {
+    .build((err, files) => {
       t.ok(!err, 'should be no error building')
 
-      parseString(files['rss.xml'].contents, function(err, result) {
+      parseString(files['rss.xml'].contents, (err, result) => {
         t.ok(!err, 'should be no error on parsing rss')
         t.ok(result, 'there should be some rss content')
 
         t.equal(result['rss']['$']['xmlns:atom'], 'http://www.w3.org/2005/Atom')
 
-        channel = result['rss']['channel'][0]
-        t.equal(channel.title[0], metadata.site.title)
-        t.equal(channel.author[0], metadata.site.author)
-        t.equal(channel.item.length, 1)
+        const channel = result['rss']['channel'][0];
+        t.equal(channel.title[0], metadata.site.title);
+        t.equal(channel.author[0], metadata.site.author);
+        t.equal(channel.item.length, 1);
 
-        post = channel.item[0]
-        t.equal(post.title[0], 'Theory of Juice')
-        t.equal(post.description[0], '<p>juice appeal</p>\n')
+        const post = channel.item[0];
+        t.equal(post.title[0], 'Theory of Juice');
+        t.equal(post.description[0], '<p>juice appeal</p>\n');
 
-        t.end()
+        t.end();
       })
     })
 })
 
-test('it complains if no tags or collections', function(t) {
+test('it complains if no tags or collections', (t) => {
   metalsmith('test/fixtures')
     .metadata(metadata)
     .use(feed({
       collection: 'posts'
     }))
-    .build(function(err, files) {
-      t.equal(err.message, 'no collections or tags configured - see metalsmith-collections or metalsmith-tags', 'no collections or tags configured - see metalsmith-collections or metalsmith-tags')
-      t.end()
+    .build((err, files) => {
+      t.equal(err.message, 'no collections or tags configured - see metalsmith-collections or metalsmith-tags', 'no collections or tags configured - see metalsmith-collections or metalsmith-tags');
+      t.end();
     })
 })
 
-test('it complains with not site.url', function(t) {
-  delete metadata.site.url
+test('it complains with not site.url', (t) => {
+  delete metadata.site.url;
   metalsmith('test/fixtures')
     .metadata(metadata)
     .use(collections({
@@ -68,8 +69,8 @@ test('it complains with not site.url', function(t) {
     .use(feed({
       collection: 'posts'
     }))
-    .build(function(err, files) {
-      t.equal(err.message, 'either site_url or metadata.site.url must be configured', 'either site_url or metadata.site.url must be configured')
-      t.end()
+    .build((err, files) => {
+      t.equal(err.message, 'either site_url or metadata.site.url must be configured', 'either site_url or metadata.site.url must be configured');
+      t.end();
     })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -25,13 +25,13 @@ test('it renders rss feed', function (t) {
     }))
     .build(function(err, files) {
       t.ok(!err, 'should be no error building')
-      
+
       parseString(files['rss.xml'].contents, function(err, result) {
         t.ok(!err, 'should be no error on parsing rss')
         t.ok(result, 'there should be some rss content')
 
         t.equal(result['rss']['$']['xmlns:atom'], 'http://www.w3.org/2005/Atom')
-        
+
         channel = result['rss']['channel'][0]
         t.equal(channel.title[0], metadata.site.title)
         t.equal(channel.author[0], metadata.site.author)
@@ -40,7 +40,7 @@ test('it renders rss feed', function (t) {
         post = channel.item[0]
         t.equal(post.title[0], 'Theory of Juice')
         t.equal(post.description[0], '<p>juice appeal</p>\n')
-        
+
         t.end()
       })
     })
@@ -73,5 +73,3 @@ test('it complains with not site.url', function(t) {
       t.end()
     })
 })
-
-


### PR DESCRIPTION
This PR changes the fork a good deal style-wise. But the main purpose of this is to add custom handling of feed item values. https://github.com/tylergaw/metalsmith-feed-js/blob/d0928ac011e33192fe6945004a27cbda3c54af4a/README.md#custom-handling-of-item-values

Test cases were written for the added functionality.
